### PR TITLE
Fix bubble merging directionality

### DIFF
--- a/models/bubble/bubble.gd
+++ b/models/bubble/bubble.gd
@@ -94,16 +94,22 @@ func _on_collision_with_bubble(other) -> void:
 		
 # Function to merge two bubbles
 func _merge_with(other) -> void:
-	if other.freeze:
+	# If the other bubble is larger, call the merge function on it
+	if other.mass > mass:
+		other._merge_with(self)
 		return
-		
-	freeze = true
 	
+	# Lock the other bubble to prevent further collisions
+	if freeze or other.freeze:
+		return
+	else:
+		other.freeze = true
+
 	# Update the current bubble
-	other.update_mass(mass + other.mass)
+	update_mass(mass + other.mass)
 	
-	# Destroy this bubble
-	queue_free()	
+	# Destroy the other bubble
+	other.queue_free()	
 
 # Function to update the scale of the bubble based on its mass
 func update_mass(new_mass: float):

--- a/scenes/experiments/4_lifecycle_emit_merge_split.tscn
+++ b/scenes/experiments/4_lifecycle_emit_merge_split.tscn
@@ -12,15 +12,16 @@ position = Vector2(320, 180)
 texture = ExtResource("1_s60kq")
 
 [node name="Bubble Emitter" type="Node2D" parent="."]
-position = Vector2(325, 286)
+position = Vector2(322, 375)
 script = ExtResource("2_ew5xc")
-spawn_rate = 2.0
-max_bubbles = 3
+spawn_rate = 2.5
+max_bubbles = 5
 spread_x = 0
 spread_y = 0
 
 [node name="RigidBody2D" parent="." instance=ExtResource("3_ytqld")]
-position = Vector2(324, 43)
+position = Vector2(323, 255)
+rotation = -0.0927751
 
 [node name="Controls" parent="." instance=ExtResource("4_6v60j")]
 


### PR DESCRIPTION
The bubble with the larger mass always survives, and the less massive bubble is removed.

Improves https://github.com/outrightmental/ggj25-bubble-up/issues/17